### PR TITLE
Add patches for issue with UART buffer overruns.

### DIFF
--- a/recipes-kernel/linux/files/0016-remove-debug-log-uart-overrun-error.patch
+++ b/recipes-kernel/linux/files/0016-remove-debug-log-uart-overrun-error.patch
@@ -1,0 +1,12 @@
+diff --git a/drivers/tty/serial/imx.c b/drivers/tty/serial/imx.c
+index c9bd603d395b..79acc2c6061b 100644
+--- a/drivers/tty/serial/imx.c
++++ b/drivers/tty/serial/imx.c
+@@ -756,7 +756,6 @@ static irqreturn_t imx_int(int irq, void *dev_id)
+ 		writel(USR1_AWAKE, sport->port.membase + USR1);
+ 
+ 	if (sts2 & USR2_ORE) {
+-		dev_err(sport->port.dev, "Rx FIFO overrun\n");
+ 		sport->port.icount.overrun++;
+ 		writel(USR2_ORE, sport->port.membase + USR2);
+ 	}

--- a/recipes-kernel/linux/files/0017-update-dma-buffer-size.patch
+++ b/recipes-kernel/linux/files/0017-update-dma-buffer-size.patch
@@ -1,0 +1,15 @@
+diff --git a/arch/arm/mach-omap2/serial.c b/arch/arm/mach-omap2/serial.c
+index 57dee0c7cd2b..c3b949d2c8df 100644
+--- a/arch/arm/mach-omap2/serial.c
++++ b/arch/arm/mach-omap2/serial.c
+@@ -66,8 +66,8 @@ static u8 console_uart_id = -1;
+ static u8 uart_debug;
+ 
+ #define DEFAULT_RXDMA_POLLRATE		1	/* RX DMA polling rate (us) */
+-#define DEFAULT_RXDMA_BUFSIZE		4096	/* RX DMA buffer size */
+-#define DEFAULT_RXDMA_TIMEOUT		(3 * HZ)/* RX DMA timeout (jiffies) */
++#define DEFAULT_RXDMA_BUFSIZE		65536	/* RX DMA buffer size */
++#define DEFAULT_RXDMA_TIMEOUT		(1 * HZ)/* RX DMA timeout (jiffies) */
+ 
+ static struct omap_uart_port_info omap_serial_default_info[] __initdata = {
+ 	{

--- a/recipes-kernel/linux/linux-variscite_4.1.15.bbappend
+++ b/recipes-kernel/linux/linux-variscite_4.1.15.bbappend
@@ -16,6 +16,8 @@ SRC_URI_append = " \
 	file://0013-add-180-degree-rotation-support.patch \
 	file://0014-disable-the-penguin-boot-logo.patch \
 	file://0015-invert-x-and-y-axis-of-usb-touch-panel.patch \
+    file://0016-remove-debug-log-uart-overrun-error.patch \
+    file://0017-update-dma-buffer-size.patch \
 "
 
 LOCALVERSION_elecex-zgateway-mx6 = "-mx6"


### PR DESCRIPTION
There is an issue with the current implementation of the Linux UART buffer.

When the buffer overruns, a synchronous debug call is made to log the buffer overrun. When the UART is constantly running close to maximum capacity, the UART driver cannot service the buffer during the synchronous request, leading to an exponential increase in buffer overruns.

This update includes two patches: 

1. remove the synchronous debug call, 
2. update the UART buffer size and decreases the timeout before the buffer will be checked.

References:
https://www.toradex.com/community/questions/2206/imx6q-rx-fifo-overrun.html
https://community.nxp.com/thread/349117


